### PR TITLE
Add '^do' to fuzzyindent for correct (doto) (and (do...)) formatting

### DIFF
--- a/indent/fennel.vim
+++ b/indent/fennel.vim
@@ -30,8 +30,8 @@ if exists("*searchpairpos")
 	endif
 
 	if !exists('g:fennel_fuzzy_indent_patterns')
-        let g:fennel_fuzzy_indent_patterns = ['^accumulate$', '^each$',
-              \ '^fn$', '^for$', '^i\?collect$', '^if', '^global$',  '^let',
+        let g:fennel_fuzzy_indent_patterns = ['^accumulate$', '^do', '^each$',
+              \ '^fn$', '^for$', '^i\?collect$', '^if', '^global$', '^let',
               \ '^lambda$', '^local$', '^macro', '^match$', '^match-try$',
               \ '^while', '^with-open$', '^var$']
 	endif


### PR DESCRIPTION
Adds '^do' to the fuzzy indenter.

Technically `do` is covered by lispwords, but `doto` was being incorrectly indented per the style guide.

This PR is maybe opinionated in that the pattern will also match `dothing`, basically expecting that most `do...` expressions will have body expressions.

This isn't unprecedented in the indenter, `^if` will match `if-let`, as will `^let` match `let-with`, etc.

If that was over reaching, the pattern could just be made `^doto$`
