### PR TITLE
Use treesitter for syntax checking when running in nvim.

### DIFF
--- a/indent/fennel.vim
+++ b/indent/fennel.vim
@@ -57,7 +57,15 @@ if exists("*searchpairpos")
 	endfunction
 
 	function! s:ignored_region()
-		return s:syn_id_name() =~? '\vstring|comment|character'
+		if s:syn_id_name() =~? '\vstring|comment|character'
+			return true
+		elseif has('nvim')
+			let captures = v:lua.vim.treesitter.get_captures_at_cursor()
+			return index(captures, 'comment') >= 0 ||
+						\ index(captures, 'string') >= 0
+		else
+			return false
+		endif
 	endfunction
 
 	function! s:current_char()


### PR DESCRIPTION
When treesitter is enabled in nvim the default syntax rules are not applied, so the synID checks always fail. This adds a check for the treesitter syntax captures.

Fixes #8 