### PR TITLE
Add Neovim 0.11 lsp config for fennel-ls.

### DIFF
--- a/lsp/fennel-ls.lua
+++ b/lsp/fennel-ls.lua
@@ -1,0 +1,5 @@
+return {
+    cmd = { "fennel-ls" },
+    root_markers = { "flsproject.fnl" },
+    filetypes = { "fennel" },
+}


### PR DESCRIPTION
Neovim 0.11 supports distributing language server configuration runtime files like syntax, indent, etc.

Note that this does not automatically activate the language server, the user needs to opt-in by calling vim.lsp.enable().